### PR TITLE
FIX + IMPROV: Negative Hops Amplification Attack Fix, validateMessage improvements, Weak PoW Mitigation. 

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -27,7 +27,7 @@ const PORT = process.env.PORT || 3000;
 
 // Rate Limiting: Semi effective mitigation to limit abuse from malicious peers / Sybil attack leveraging weak PoW. 100 new peers per 5 seconds per connection.
 const RATE_LIMIT_WINDOW = 5000;
-const RATE_LIMIT_MAX_NEW_PEERS = 100;
+const RATE_LIMIT_MAX_NEW_PEERS = 1000;
 
 module.exports = {
     TOPIC_NAME,

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -25,6 +25,10 @@ const BROADCAST_THROTTLE = 1000;
 const DIAGNOSTICS_INTERVAL = 10000;
 const PORT = process.env.PORT || 3000;
 
+// Rate Limiting: Semi effective mitigation to limit abuse from malicious peers / Sybil attack leveraging weak PoW. 100 new peers per 5 seconds per connection.
+const RATE_LIMIT_WINDOW = 5000;
+const RATE_LIMIT_MAX_NEW_PEERS = 100;
+
 module.exports = {
     TOPIC_NAME,
     TOPIC,
@@ -39,4 +43,6 @@ module.exports = {
     BROADCAST_THROTTLE,
     DIAGNOSTICS_INTERVAL,
     PORT,
+    RATE_LIMIT_WINDOW,
+    RATE_LIMIT_MAX_NEW_PEERS,
 };

--- a/src/p2p/messaging.js
+++ b/src/p2p/messaging.js
@@ -65,7 +65,8 @@ class MessageHandler {
             }
 
             // Only relay if we haven't already relayed this message (bloom filter check)
-            if (hops < MAX_RELAY_HOPS && !this.bloomFilter.hasRelayed(id, seq)) {
+            // Security: hops must be >= 0 to prevent negative hops bypass attack
+            if (hops >= 0 && hops < MAX_RELAY_HOPS && !this.bloomFilter.hasRelayed(id, seq)) {
                 this.bloomFilter.markRelayed(id, seq);
                 this.diagnostics.increment("heartbeatsRelayed");
                 this.relayCallback({ ...msg, hops: hops + 1 }, sourceSocket);
@@ -97,7 +98,7 @@ class MessageHandler {
             this.broadcastCallback();
 
             // Use id:leave as key for LEAVE messages
-            if (hops < MAX_RELAY_HOPS && !this.bloomFilter.hasRelayed(id, "leave")) {
+            if (hops >= 0 && hops < MAX_RELAY_HOPS && !this.bloomFilter.hasRelayed(id, "leave")) {
                 this.bloomFilter.markRelayed(id, "leave");
                 this.relayCallback({ ...msg, hops: hops + 1 }, sourceSocket);
             }
@@ -116,15 +117,20 @@ const validateMessage = (msg) => {
         const allowedFields = ['type', 'id', 'seq', 'hops', 'nonce', 'sig'];
         const fields = Object.keys(msg);
         return fields.every(f => allowedFields.includes(f)) &&
-            msg.id && typeof msg.seq === 'number' &&
-            typeof msg.hops === 'number' && msg.nonce && msg.sig;
+            typeof msg.id === 'string' && msg.id.length > 0 &&
+            typeof msg.seq === 'number' && Number.isInteger(msg.seq) && msg.seq >= 0 &&
+            typeof msg.hops === 'number' && Number.isInteger(msg.hops) && msg.hops >= 0 &&
+            typeof msg.nonce === 'number' && Number.isInteger(msg.nonce) && msg.nonce >= 0 &&
+            typeof msg.sig === 'string' && msg.sig.length > 0;
     }
 
     if (msg.type === "LEAVE") {
         const allowedFields = ['type', 'id', 'hops', 'sig'];
         const fields = Object.keys(msg);
         return fields.every(f => allowedFields.includes(f)) &&
-            msg.id && typeof msg.hops === 'number' && msg.sig;
+            typeof msg.id === 'string' && msg.id.length > 0 &&
+            typeof msg.hops === 'number' && Number.isInteger(msg.hops) && msg.hops >= 0 &&
+            typeof msg.sig === 'string' && msg.sig.length > 0;
     }
 
     return false;

--- a/src/p2p/messaging.js
+++ b/src/p2p/messaging.js
@@ -67,7 +67,7 @@ class MessageHandler {
                     if (!sourceSocket.rateLimiter || now > sourceSocket.rateLimiter.resetTime) {
                         sourceSocket.rateLimiter = { count: 0, resetTime: now + RATE_LIMIT_WINDOW };
                     }
-                    if (++sourceSocket.rateLimiter.count > RATE_LIMIT_MAX_NEW_PEERS) {
+                    if (++sourceSocket.rateLimiter.count >= RATE_LIMIT_MAX_NEW_PEERS) {
                         this.diagnostics.increment("rateLimitedConnections");
                         sourceSocket.destroy();
                         return;

--- a/src/state/diagnostics.js
+++ b/src/state/diagnostics.js
@@ -12,6 +12,7 @@ class DiagnosticsManager {
             bytesReceived: 0,
             bytesRelayed: 0,
             leaveMessages: 0,
+            rateLimitedConnections: 0,
         };
 
         this.interval = null;


### PR DESCRIPTION
<img width="960" height="404" alt="image" src="https://github.com/user-attachments/assets/ae46d43c-c46a-465b-83b6-9d27536f64c7" />


## Negative Hops Relay Amplification
Relay condition validation allowed negative values, by sending -100 you can cause 102 relay hops. Observed during testing that setting -100 would cause a massive increase in duplicate messages received back from testnet. 

## validateMessage is loosely validating
This one doesn't seem impacting but adding additional validation here seems good. Could reduce performance impact of attempted abuse by rejecting earlier.

## Weak PoW Mitigation 
Assuming you can't change the PoW to 00000 from 0000, I was able to generate 100,000 Identities and broadcast these into a testnet easily with a cheap VPS. 

An easy win fix here seems to be introducing a rate limit on the number of peers accepted over a single connection, This is a suggestion and could be tailored to network rate. Setting this to 1000 new peers over a 5s window limit the impact without raising the PoW or currently limiting the dopamine network. 

Sybil attack PoC for this can be seen in base branch of my fork repo as `troll_parallel_v2.js`

## Give all of these a proper test, I'm terrible at Javascript. 
