### PR TITLE
Announce Hypermind-Swarm fork and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ It solves the critical infrastructure challenge of knowing exactly how many othe
 
 ---
 
+## Special Announcement
+
+Apparently the counter was not enough.
+
+[Hypermind-Swarm](https://github.com/lklynet/hypermind-swarm) is a fork of Hypermind that takes the same P2P bones and turns them into a Twitter-style social platform for decentralized, ephemeral conversations.
+
+It is built by the same creator, still allergic to central servers, still running on the swarm, and now aimed at letting people post into the void without algorithms, permanent digital footprints, or anyone pretending this needed to exist.
+
+---
+
 ## What is this?
 
 You need a service that:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hypermind",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hypermind",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^17.2.3",


### PR DESCRIPTION
## Summary
- Add a new announcement section to the README introducing [Hypermind-Swarm](https://github.com/lklynet/hypermind-swarm) as a fork of Hypermind.
- Position Hypermind-Swarm as a Twitter-style decentralized social platform built on the same P2P foundation.
- Bump the package lock version from `1.0.0` to `1.0.1`.

## Testing
- Not run (documentation and version bump only).
- Verified the README diff for the new announcement section.
- Verified `package-lock.json` version fields were updated to `1.0.1`.